### PR TITLE
[docs] Don't clobber global unexpected instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Now let's assert that after invoking `fetchData` the `data`
 property eventually gets set and `error` remains `null`:
 
 ```js
-import expect from 'unexpected';
+import unexpected from 'unexpected';
 import unexpectedMobX from 'unexpected-mobx';
 
-expect.use(unexpectedMobX);
+const expect = unexpected.clone().use(unexpectedMobX);
 
 expect(store.fetchData,
   'when observing',


### PR DESCRIPTION
The recommendation is to always `.clone()` before adding the plugins in a test, otherwise the global instance has the plugins, which could mean they get added more than once.